### PR TITLE
Починил чтение настройки SILERO_TIME_LIMIT

### DIFF
--- a/Silero.py
+++ b/Silero.py
@@ -174,7 +174,7 @@ class TelegramBotHandler:
 
         attempts_max = self.silero_time_limit * attempts_per_second
 
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.2)
         while attempts <= attempts_max:  # Попытки получения ответа
 
             async for message in self.client.iter_messages(self.tg_bot, limit=1):

--- a/gui.py
+++ b/gui.py
@@ -710,7 +710,7 @@ class ChatGUI:
     def validate_number(self, new_value):
         if not new_value.isdigit():  # Проверяем, что это число
             return False
-        return 0 < int(new_value) <= 30  # Проверяем, что в пределах диапазона
+        return 0 <= int(new_value) <= 60  # Проверяем, что в пределах диапазона
 
     def pack_unpack(self, var, frame):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,5 @@ typing-extensions==4.12.2
 typing-inspect==0.9.0
 urllib3==2.3.0
 yarl==1.18.3
+emoji
+binascii

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,4 +66,3 @@ typing-inspect==0.9.0
 urllib3==2.3.0
 yarl==1.18.3
 emoji
-binascii


### PR DESCRIPTION
Критично. Починил чтение настройки SILERO_TIME_LIMIT
Увеличил задержку до начала получения ответа от бота с 0.7 секунд до 2 секунд (Silero.py строка 168).
Снизил частоту запросов до двух в секунду (Silero.py строка 172).
Критично. Фикс ввода числа в поле TG_TIME_LIMIT в строке 713
Критично. Удаляем смайлы из сообщения перед отправкой ТГ боту.